### PR TITLE
added creation of nonexisting recursive paths when specifying path separators in format string

### DIFF
--- a/renrot
+++ b/renrot
@@ -17,6 +17,7 @@ use Image::ExifTool;
 use Getopt::Long;
 use File::Spec;
 use File::Basename;
+use File::Path;
 
 # add our 'lib' directory to the include list
 my $exeDir;
@@ -753,6 +754,11 @@ sub renameFile {
         die_renrot("File $newFileName already exists!\n");
       }
       if ($dryRun == 0) {
+        my $newDirName = dirname($newFileName);
+        if ( ! -d $newDirName )
+        {
+          mkpath ($newDirName);
+        }
         rename ($file, $newFileName) || die_renrot("Unable to rename $file -> $newFileName.\n");
       }
       procmsg ("Renamed: $file -> $newFileName\n");


### PR DESCRIPTION
Hi,

I'd like to have creation of subdirectories when specifying path separators in format - to get a directory tree similar to F-Spot or iPhoto.

The following format string works with my patch:

renrot -n "%Y/%m/%d/%H%M%S-%O" *RAF

Best regards
/Thomas
